### PR TITLE
Refactor: large-scale restructure at 2025-06

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,5 @@ node_modules
 .env
 .DS_Store
 syntaxes/*.json
-src/grammar.d.ts
-src/grammar.js
+src/parser.d.ts
+src/parser.js

--- a/package.json
+++ b/package.json
@@ -345,9 +345,9 @@
 	"scripts": {
 		"vscode:prepublish": "pnpm run js-yaml && pnpm run package",
 		"compile": "pnpm run compile:peggy && pnpm run check-types && pnpm run lint && node esbuild.js",
-		"compile:peggy": "peggy -c ./src/pegconfig.json",
+		"compile:peggy": "peggy --dts --cache src/parser.peggy",
 		"watch": "npm-run-all -p watch:*",
-		"watch:peggy": "peggy -w -c ./src/pegconfig.json",
+		"watch:peggy": "peggy -w --dts --cache src/parser.peggy",
 		"watch:esbuild": "node esbuild.js --watch",
 		"watch:tsc": "tsc --noEmit --watch --project tsconfig.json",
 		"package": "pnpm run compile:peggy && pnpm run check-types && pnpm run lint && node esbuild.js --production",

--- a/package.json
+++ b/package.json
@@ -372,8 +372,6 @@
 	"devDependencies": {
 		"@esbuild-plugins/node-globals-polyfill": "^0.2.3",
 		"@types/assert": "^1.5.11",
-		"@types/estraverse": "^5.1.7",
-		"@types/estree": "^1.0.8",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "20.x",
 		"@types/semver": "^7.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,12 +21,6 @@ importers:
       '@types/assert':
         specifier: ^1.5.11
         version: 1.5.11
-      '@types/estraverse':
-        specifier: ^5.1.7
-        version: 5.1.7
-      '@types/estree':
-        specifier: ^1.0.8
-        version: 1.0.8
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
@@ -364,9 +358,6 @@ packages:
 
   '@types/assert@1.5.11':
     resolution: {integrity: sha512-FjS1mxq2dlGr9N4z72/DO+XmyRS3ZZIoVn998MEopAN/OmyN28F4yumRL5pOw2z+hbFLuWGYuF2rrw5p11xM5A==}
-
-  '@types/estraverse@5.1.7':
-    resolution: {integrity: sha512-JRVtdKYZz7VkNp7hMC/WKoiZ8DS3byw20ZGoMZ1R8eBrBPIY7iBaDAS1zcrnXQCwK44G4vbXkimeU7R0VLG8UQ==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -2341,10 +2332,6 @@ snapshots:
       playwright-core: 1.53.0
 
   '@types/assert@1.5.11': {}
-
-  '@types/estraverse@5.1.7':
-    dependencies:
-      '@types/estree': 1.0.8
 
   '@types/estree@1.0.8': {}
 

--- a/src/parser.peggy
+++ b/src/parser.peggy
@@ -16,9 +16,9 @@
 
 /**
  * JSDoc-style type definitions.
- * @typedef { import('./grammar').LocationRange } LocationRange
- * @typedef { import('./grammar').Location } Location
- * @typedef { import('./grammar').GrammarSource } GrammarSource
+ * @typedef { import('./parser').LocationRange } LocationRange
+ * @typedef { import('./parser').Location } Location
+ * @typedef { import('./parser').GrammarSource } GrammarSource
 
 * @typedef { import('./tree').Node } Node
 * @typedef { import('./tree').Expression } Expression

--- a/src/pegconfig.json
+++ b/src/pegconfig.json
@@ -1,6 +1,0 @@
-{
-    "cache": true,
-    "dts": true,
-    "input": "src/grammar.pegjs",
-    "output": "src/grammar.js"
-}

--- a/src/specCommand.ts
+++ b/src/specCommand.ts
@@ -1,14 +1,6 @@
 import * as vscode from 'vscode';
 import type { LocationRange, Location } from './grammar';
 
-export function convertPosition(position: Location): vscode.Position {
-    return new vscode.Position(position.line - 1, position.column - 1);
-}
-
-export function convertRange(range: LocationRange): vscode.Range {
-    return new vscode.Range(convertPosition(range.start), convertPosition(range.end));
-}
-
 export const SELECTOR = { language: 'spec-command' };
 // export const SELECTOR = [{ scheme: 'file', language: 'spec-command' }, { scheme: 'untitled', language: 'spec-command' }];
 export const BUILTIN_URI = 'spec-command://system/built-in.md';
@@ -18,100 +10,15 @@ export const SNIPPET_URI = 'spec-command://system/code-snippet.md';
 export const ACTIVE_FILE_URI = 'spec-command://user/active-document.md';
 export const AST_URI = 'spec-command://user/ast.json';
 
-export const enum ReferenceItemKind {
-    Undefined = 0,
-    Constant,
-    Variable,
-    Array,
-    Macro,
-    Function,
-    Keyword,
-    Snippet,
-    Enum,
+export function convertPosition(position: Location): vscode.Position {
+    return new vscode.Position(position.line - 1, position.column - 1);
 }
 
-type ReferenceItemKindMetadata = { label: string, iconIdentifier: string, completionItemKind: vscode.CompletionItemKind | undefined, symbolKind: vscode.SymbolKind };
-
-export function getReferenceItemKindMetadata(refItemKind: ReferenceItemKind) : ReferenceItemKindMetadata {
-    switch (refItemKind) {
-        case ReferenceItemKind.Constant:
-            return {
-                label: "constant",
-                iconIdentifier: 'symbol-constant',
-                completionItemKind: vscode.CompletionItemKind.Constant,
-                symbolKind: vscode.SymbolKind.Constant
-            };
-        case ReferenceItemKind.Variable:
-            return {
-                label: "variable",
-                iconIdentifier: 'symbol-variable',
-                completionItemKind: vscode.CompletionItemKind.Variable,
-                symbolKind: vscode.SymbolKind.Variable
-            };
-            case ReferenceItemKind.Array:
-                return {
-                    label: "data-array",
-                    iconIdentifier: 'symbol-array',
-                    completionItemKind: vscode.CompletionItemKind.Variable,
-                    symbolKind: vscode.SymbolKind.Array
-                };
-            case ReferenceItemKind.Macro:
-            return {
-                label: "macro",
-                iconIdentifier: 'symbol-module',
-                completionItemKind: vscode.CompletionItemKind.Module,
-                symbolKind: vscode.SymbolKind.Module
-            };
-        case ReferenceItemKind.Function:
-            return {
-                label: "function",
-                iconIdentifier: 'symbol-function',
-                completionItemKind: vscode.CompletionItemKind.Function,
-                symbolKind: vscode.SymbolKind.Function
-            };
-        case ReferenceItemKind.Keyword:
-            return {
-                label: "keyword",
-                iconIdentifier: 'symbol-keyword',
-                completionItemKind: vscode.CompletionItemKind.Keyword,
-                symbolKind: vscode.SymbolKind.Null // no corresponding value
-            };
-        case ReferenceItemKind.Snippet:
-            return {
-                label: "snippet",
-                iconIdentifier: 'symbol-snippet',
-                completionItemKind: vscode.CompletionItemKind.Snippet,
-                symbolKind: vscode.SymbolKind.Null // no corresponding value
-            };
-        case ReferenceItemKind.Enum:
-            return {
-                label: "member",
-                iconIdentifier: 'symbol-enum-member',
-                completionItemKind: vscode.CompletionItemKind.EnumMember,
-                symbolKind: vscode.SymbolKind.EnumMember
-            };
-        case ReferenceItemKind.Undefined:
-            return {
-                label: "unknown symbol",
-                iconIdentifier: 'symbol-null',
-                completionItemKind: undefined,
-                symbolKind: vscode.SymbolKind.Null
-            };
-    }
+export function convertRange(range: LocationRange): vscode.Range {
+    return new vscode.Range(convertPosition(range.start), convertPosition(range.end));
 }
 
-export class CompletionItem extends vscode.CompletionItem {
-    readonly uriString: string;
-    readonly refItemKind: ReferenceItemKind;
-
-    constructor(label: string | vscode.CompletionItemLabel, uriString: string, refItemKind: ReferenceItemKind) {
-        super(label, getReferenceItemKindMetadata(refItemKind).completionItemKind);
-        this.uriString = uriString;
-        this.refItemKind = refItemKind;
-    };
-}
-
-// 'overloads' parameter is for built-in macros and functions.
+// 'overloads' parameter is used only by built-in macros and functions.
 export type ReferenceItem = {
     signature: string;
     description?: string;
@@ -130,6 +37,16 @@ export type VersionRange = {
     description?: string;
 };
 
+export type ReferenceSheet = Map<string, ReferenceItem>;
+
+const ReferenceCategoryNames = ['undefined', 'constant', 'variable', 'array', 'macro', 'function', 'keyword', 'snippet', 'enum'] as const;
+
+export type ReferenceCategory = typeof ReferenceCategoryNames[number];
+export type ReferenceBook = { [K in ReferenceCategory]?: ReferenceSheet; };
+// export type ReferenceBook = Map<ReferenceCategory, ReferenceSheet>;
+
+type ReferenceCategoryMetadata = { label: string, iconIdentifier: string, completionItemKind: vscode.CompletionItemKind | undefined, symbolKind: vscode.SymbolKind };
+
 export function getVersionRangeDescription(versionRange: VersionRange, label: string) {
     let tmpStr = versionRange.range === '>=0.0.0' ? `[${label} at some time]` : `[${label}: \`${versionRange.range}\`]`;
     if (versionRange.description) {
@@ -138,6 +55,70 @@ export function getVersionRangeDescription(versionRange: VersionRange, label: st
     return tmpStr;
 }
 
-export type ReferenceMap = Map<string, ReferenceItem>;
+export const referenceCategoryMetadata: { [K in ReferenceCategory]: ReferenceCategoryMetadata } = {
+    constant: {
+        label: 'constant',
+        iconIdentifier: 'symbol-constant',
+        completionItemKind: vscode.CompletionItemKind.Constant,
+        symbolKind: vscode.SymbolKind.Constant
+    },
+    variable: {
+        label: 'variable',
+        iconIdentifier: 'symbol-variable',
+        completionItemKind: vscode.CompletionItemKind.Variable,
+        symbolKind: vscode.SymbolKind.Variable
+    },
+    array: {
+        label: 'data-array',
+        iconIdentifier: 'symbol-array',
+        completionItemKind: vscode.CompletionItemKind.Variable,
+        symbolKind: vscode.SymbolKind.Array
+    },
+    macro: {
+        label: 'macro',
+        iconIdentifier: 'symbol-module',
+        completionItemKind: vscode.CompletionItemKind.Module,
+        symbolKind: vscode.SymbolKind.Module
+    },
+    function: {
+        label: 'function',
+        iconIdentifier: 'symbol-function',
+        completionItemKind: vscode.CompletionItemKind.Function,
+        symbolKind: vscode.SymbolKind.Function
+    },
+    keyword: {
+        label: 'keyword',
+        iconIdentifier: 'symbol-keyword',
+        completionItemKind: vscode.CompletionItemKind.Keyword,
+        symbolKind: vscode.SymbolKind.Null // no corresponding value
+    },
+    snippet: {
+        label: 'snippet',
+        iconIdentifier: 'symbol-snippet',
+        completionItemKind: vscode.CompletionItemKind.Snippet,
+        symbolKind: vscode.SymbolKind.Null // no corresponding value
+    },
+    enum: {
+        label: 'member',
+        iconIdentifier: 'symbol-enum-member',
+        completionItemKind: vscode.CompletionItemKind.EnumMember,
+        symbolKind: vscode.SymbolKind.EnumMember
+    },
+    undefined: {
+        label: 'unknown symbol',
+        iconIdentifier: 'symbol-null',
+        completionItemKind: undefined,
+        symbolKind: vscode.SymbolKind.Null
+    }
+};
 
-export type ReferenceStorage = Map<ReferenceItemKind, ReferenceMap>;
+export class CompletionItem extends vscode.CompletionItem {
+    readonly uriString: string;
+    readonly category: ReferenceCategory;
+
+    constructor(label: string | vscode.CompletionItemLabel, uriString: string, category: ReferenceCategory) {
+        super(label, referenceCategoryMetadata[category].completionItemKind);
+        this.uriString = uriString;
+        this.category = category;
+    };
+}

--- a/src/specCommand.ts
+++ b/src/specCommand.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import type { LocationRange, Location } from './grammar';
+import type { LocationRange, Location } from './parser';
 
 export const SELECTOR = { language: 'spec-command' };
 // export const SELECTOR = [{ scheme: 'file', language: 'spec-command' }, { scheme: 'untitled', language: 'spec-command' }];

--- a/src/traverser.ts
+++ b/src/traverser.ts
@@ -1,0 +1,249 @@
+import * as vscode from 'vscode';
+import * as estree from 'estree';
+import * as estraverse from 'estraverse';
+import * as lang from './specCommand';
+import type { LocationRange } from './grammar';
+
+/**
+ * Extention-specific keys for estraverse (not exist in the original Parser AST.)
+ */
+const ADDITIONAL_TRAVERSE_KEYS = {
+    MacroStatement: ['arguments'],
+    InvalidStatement: [],
+    ExitStatement: [],
+    QuitStatement: [],
+    NullExpression: [],
+};
+
+export function traverseWholly(program: estree.Program): [lang.ReferenceBook, vscode.DocumentSymbol[]] {
+    // Create variables to store data.
+    const refBook = {
+        constant: new Map<string, lang.ReferenceItem>(),
+        variable: new Map<string, lang.ReferenceItem>(),
+        array: new Map<string, lang.ReferenceItem>(),
+        macro: new Map<string, lang.ReferenceItem>(),
+        function: new Map<string, lang.ReferenceItem>(),
+    };
+    const symbols: vscode.DocumentSymbol[] = [];
+
+    // Traverse the syntax tree.
+    estraverse.traverse(program, {
+        enter: (node, parent) => {
+            // console.log('enter', node.type, parent?.type);
+
+            if (parent === null && node.type === 'Program') {
+                // if it is a top-level, dig in.
+                return;
+            } else if (!node.type.endsWith('Statement') && !node.type.endsWith('Declaration')) {
+                // if not any type of statements, skip.
+                return estraverse.VisitorOption.Skip;
+            } else if (!node.loc) {
+                console.log('Statement should have location. This may be a bug in the parser.');
+                return;
+            }
+
+            const nodeRange = lang.convertRange(node.loc as LocationRange);
+
+            // Treat a line comment starting with `MARK|TODO|FIXME` as a symbol.
+            if (node.leadingComments) {
+                for (const leadingComment of node.leadingComments) {
+                    let matched: RegExpMatchArray | null;
+                    if (leadingComment.type === 'Line' && leadingComment.loc && (matched = leadingComment.value.match(/^(\s*(MARK|TODO|FIXME):\s+)((?:(?!--).)+)(?:--\s*(.+))?$/)) !== null) {
+                        const range1 = lang.convertRange(leadingComment.loc as LocationRange);
+                        const range2 = range1.with(range1.start.translate(undefined, matched[1].length + 1));
+                        const symbol = new vscode.DocumentSymbol(matched[3], matched[4] !== undefined ? matched[4] : '', vscode.SymbolKind.Key, range1, range2);
+                        if (symbols.length !== 0 && symbols[symbols.length - 1].range.contains(range1)) {
+                            symbols[symbols.length - 1].children.push(symbol);
+                        } else {
+                            symbols.push(symbol);
+                        }
+                    }
+                }
+            }
+
+            if (node.type === 'FunctionDeclaration') {
+                // Register a document symbol.
+                if (node.id && node.id.loc) {
+                    const idName = node.id.name;
+                    const idRange = lang.convertRange(node.id.loc as LocationRange);
+
+                    let symbolKind: vscode.SymbolKind;
+                    if (node.params) {
+                        symbolKind = vscode.SymbolKind.Function;
+                        // const params = currentNode.params.map(param => (param.type === 'Identifier') ? param.name : '') ;
+                        // symbol = new vscode.DocumentSymbol(idName, '(' + params.join(' ,') + ')', vscode.SymbolKind.Function, stmtRange, idRange);
+                    } else {
+                        symbolKind = vscode.SymbolKind.Module;
+                    }
+                    const symbol = new vscode.DocumentSymbol(idName, '', symbolKind, nodeRange, idRange);
+
+                    if (symbols.length !== 0 && symbols[symbols.length - 1].range.contains(nodeRange)) {
+                        symbols[symbols.length - 1].children.push(symbol);
+                    } else {
+                        symbols.push(symbol);
+                    }
+                }
+
+                // Register a top-level item as a reference item.
+                if (parent?.type === 'Program') {
+                    if (node.params) {
+                        // Register the id as a function if parameter is not null.
+                        const signature = `${node.id.name}(${node.params.map(param => (param.type === 'Identifier') ? param.name : '').join(', ')})`;
+                        refBook.function.set(node.id.name, makeReferenceItem(node, signature));
+                    } else {
+                        // Register the id as a traditional macro if parameter is null.
+                        refBook.macro.set(node.id.name, makeReferenceItem(node, node.id.name));
+                    }
+                }
+
+            } else if (node.type === 'VariableDeclaration') {
+                // Register a document symbol.
+                for (const declarator of node.declarations) {
+                    if (declarator.type === 'VariableDeclarator' && declarator.id.type === 'Identifier' && declarator.id.loc) {
+                        const idName = declarator.id.name;
+                        const idRange = lang.convertRange(declarator.id.loc as LocationRange);
+                        const idDetail = '';
+                        // const idDetail = (declarator.init && declarator.init.type === 'Literal' && declarator.init.raw) ? ' = ' + declarator.init.raw : '';
+                        let symbolKind: vscode.SymbolKind;
+                        if (node.kind === 'const') {
+                            symbolKind = vscode.SymbolKind.Constant;
+                        } else if (node.kind === 'let') {
+                            symbolKind = vscode.SymbolKind.Variable;
+                        } else {
+                            symbolKind = vscode.SymbolKind.Array;
+                        }
+                        const symbol = new vscode.DocumentSymbol(idName, idDetail, symbolKind, idRange, idRange);
+                        if (symbols.length !== 0 && symbols[symbols.length - 1].range.contains(nodeRange)) {
+                            symbols[symbols.length - 1].children.push(symbol);
+                        } else {
+                            symbols.push(symbol);
+                        }
+                    }
+                }
+
+                // Register a top-level item as a reference item.
+                if (parent?.type === 'Program') {
+                    for (const declarator of node.declarations) {
+                        if (declarator.type === "VariableDeclarator" && declarator.id.type === 'Identifier') {
+                            const signature =
+                                declarator.init && declarator.init.type === 'Literal' ?
+                                    `${declarator.id.name} = ${declarator.init.raw}` :
+                                    declarator.id.name;
+                            const refItem = makeReferenceItem(node, signature);
+                            if (node.kind === 'const') {
+                                refBook.constant.set(declarator.id.name, refItem);
+                            } else if (node.kind === 'let') {
+                                refBook.variable.set(declarator.id.name, refItem);
+                            } else {
+                                refBook.array.set(declarator.id.name, refItem);
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        // leave: (node, parent) => {
+        //     console.log('leave', node.type, parent?.type);
+        // },
+        keys: ADDITIONAL_TRAVERSE_KEYS,
+    });
+
+    return [refBook, symbols];
+}
+
+export function traversePartially(program: estree.Program, position: vscode.Position): lang.ReferenceBook {
+    // Create variables to store data.
+    const refBook = {
+        constant: new Map<string, lang.ReferenceItem>(),
+        variable: new Map<string, lang.ReferenceItem>(),
+        array: new Map<string, lang.ReferenceItem>(),
+        macro: new Map<string, lang.ReferenceItem>(),
+        function: new Map<string, lang.ReferenceItem>(),
+    };
+
+    // Traverse the syntax tree.
+    estraverse.traverse(program, {
+        enter: (node, parent) => {
+            // console.log('enter', node.type, parent?.type);
+
+            if (parent === null && node.type === 'Program') {
+                // if it is a top-level, dig in.
+                return;
+            } else if (!node.type.endsWith('Statement') && !node.type.endsWith('Declaration')) {
+                // if not any type of statements, skip.
+                return estraverse.VisitorOption.Skip;
+            } else if (!node.loc) {
+                console.log('Statement should have location. This may be a bug in the parser.');
+                return;
+            }
+
+            const nodeRange = lang.convertRange(node.loc as LocationRange);
+
+            // in case of active document
+            // if (nodeRange.contains(position)) {
+            //     nestedNodes.push(node.type);
+            // }
+
+            if (node.type === 'BlockStatement' && nodeRange.end.isBefore(position)) {
+                // Skip the code block that ends before the cursor.
+                return estraverse.VisitorOption.Skip;
+
+            } else if (node.type === 'FunctionDeclaration' && node.params && nodeRange.contains(position)) {
+                // Register arguments of function as variables if the cursor is in the function block.
+                for (const param of node.params) {
+                    if (param.type === 'Identifier') {
+                        const refItem = { signature: param.name, location: node.loc as LocationRange };
+                        refBook.variable.set(param.name, refItem);
+                    }
+                }
+            } else if (nodeRange.start.isAfter(position)) {
+                return estraverse.VisitorOption.Break;
+            }
+
+            if (parent?.type !== 'Program') {
+                if (node.type === 'FunctionDeclaration' && node.id) {
+                    if (node.params) {
+                        // register the id as a function if parameter is not null.
+                        const signature = `${node.id.name}(${node.params.map(param => (param.type === 'Identifier') ? param.name : '').join(', ')})`;
+                        refBook.function.set(node.id.name, makeReferenceItem(node, signature));
+                    } else {
+                        // register the id as a traditional macro if parameter is null.
+                        refBook.macro.set(node.id.name, makeReferenceItem(node, node.id.name));
+                    }
+                } else if (node.type === 'VariableDeclaration') {
+                    for (const declarator of node.declarations) {
+                        if (declarator.type === "VariableDeclarator" && declarator.id.type === 'Identifier') {
+                            const signature =
+                                declarator.init && declarator.init.type === 'Literal' ?
+                                    `${declarator.id.name} = ${declarator.init.raw}` :
+                                    declarator.id.name;
+                            const refItem = makeReferenceItem(node, signature);
+                            if (node.kind === 'const') {
+                                refBook.constant.set(declarator.id.name, refItem);
+                            } else if (node.kind === 'let') {
+                                refBook.variable.set(declarator.id.name, refItem);
+                            } else {
+                                refBook.array.set(declarator.id.name, refItem);
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        // leave: (node, parent) => {
+        //     console.log('leave', node.type, parent?.type);
+        // },
+        keys: ADDITIONAL_TRAVERSE_KEYS,
+    });
+
+    return refBook;
+}
+
+function makeReferenceItem(node: estree.Node, signature: string): lang.ReferenceItem {
+    // Create a reference item from the node and signature string.
+    const refItem: lang.ReferenceItem = { signature, location: node.loc as LocationRange };
+    if (node.leadingComments && node.leadingComments.length > 0) {
+        refItem.description = node.leadingComments[node.leadingComments.length - 1].value;
+    }
+    return refItem;
+}

--- a/src/traverser.ts
+++ b/src/traverser.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 // import * as estraverse from 'estraverse';
 import * as lang from './specCommand';
-import type { LocationRange } from './grammar';
+import type { LocationRange } from './parser';
 import type * as tree from './tree';
 
 const estraverse = require('estraverse');

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -1,0 +1,552 @@
+/*
+Type Definitions for spec language.
+
+See LICENSE for the license of this file.
+
+The extension author (@fujidana) has borrowed the naming convention of nodes 
+from ESTree. However, owing to the grammatical difference between JavaScript 
+and spec, the type definitions between them also have considerable differences.
+
+The referred file is index.d.ts in @types/estraverse v5.1.7, obtained from:
+
+https://www.npmjs.com/package/@types/estraverse
+https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/estraverse/index.d.ts
+
+The license of the referred file is as follows:
+/*
+
+/* 
+    MIT License
+
+    Copyright (c) Microsoft Corporation.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE
+ */
+
+import type { DiagnosticSeverity } from 'vscode';
+import type { LocationRange } from './grammar';
+
+/**
+ * Node having a similar structure as `estree.BaseNodeWithoutComments`.
+ * The type for `loc` property is not `estree.SourceLocation` but
+ * `LocationRange` of Peggy.js parser.
+ */
+interface BaseNodeWithoutComments {
+    type: string;
+    loc?: LocationRange;
+}
+
+/** Node having the same structure as `estree.BaseNode`. */
+interface BaseNode extends BaseNodeWithoutComments {
+    leadingComments?: Comment[] | undefined;
+    trailingComments?: Comment[] | undefined;
+}
+
+interface NodeMap {
+    Program: Program;
+
+    Statement: Statement;
+    Expression: Expression;
+
+    VariableDeclarator: VariableDeclarator;
+    InternalDataArrayDeclarator: InternalDataArrayDeclarator;
+    ExternalDataArrayDeclarator: ExternalDataArrayDeclarator;
+    MemberAccessProperty: MemberAccessProperty;
+    SliceElement: SliceElement;
+    Property: Property;
+    MacroParameter: MacroParameter;
+}
+
+export type Node = NodeMap[keyof NodeMap];
+
+// // export type ChildStatement = InMenuStatement | InPictureStatement | InStructureStatement | InFunctionStatement;
+
+/** Node having the same structure as `estree.Comment`. */
+export interface Comment extends BaseNodeWithoutComments {
+    type: 'Line' | 'Block';
+    value: string;
+}
+
+// export interface BaseBlock extends BaseStatement {
+//     innerComments?: Comment[];
+// }
+
+/** Custom node for representing problems in the code. */
+export interface Problem extends BaseNode {
+    message: string;
+    severity: DiagnosticSeverity;
+    loc: LocationRange;
+}
+
+/**
+ * Node having similar structure to `estree.Program` but
+ * `problems` property added and `sourceType` and `comments` removed.
+ */
+export interface Program extends BaseNode {
+    type: 'Program';
+    body: Statement[];
+    problems: Problem[];
+}
+
+export type Statement =
+    | BlockStatement
+    | FunctionDeclaration
+    | IfStatement
+    | WhileStatement
+    | ForStatement
+    | ForInStatement
+    | BreakStatement
+    | ContinueStatement
+    | ReturnStatement
+    | VariableDeclaration
+    | ExpressionStatement
+
+ // specific to spec, not included in ESTree
+    | ExitStatement
+    | QuitStatement
+    | DataArrayDeclaration
+
+    | EmptyStatement
+    | UnclassifiedStatement;
+
+
+export interface BaseStatement extends BaseNode { }
+
+/** Node having the same structure as `estree.EmptyStatement`. */
+export interface EmptyStatement extends BaseStatement {
+    type: 'EmptyStatement';
+}
+
+/** Node having the same structure as `estree.BlockStatement`. */
+export interface BlockStatement extends BaseStatement {
+    type: 'BlockStatement';
+    body: Statement[];
+    innerComments?: Comment[] | undefined;
+}
+
+/** Custom node to catch unclassified statements. */
+export interface UnclassifiedStatement extends BaseStatement {
+    type: 'UnclassifiedStatement';
+    value: string;
+}
+
+/** Node having the same structure as `estree.IfStatement`. */
+export interface IfStatement extends BaseStatement {
+    type: 'IfStatement';
+    test: Expression;
+    consequent: Statement;
+    alternate?: Statement | null | undefined;
+}
+
+/** Node having the same structure as `estree.WhileStatement`. */
+export interface WhileStatement extends BaseStatement {
+    type: 'WhileStatement';
+    test: Expression;
+    body: Statement;
+}
+
+/** Node having nearly the same structure as `estree.ForStatement`. */
+export interface ForStatement extends BaseStatement {
+    type: 'ForStatement';
+    init?: Expression | null | undefined; // Unlike JavaScript, VariableDeclaration is unavailable here.
+    test?: Expression | null | undefined;
+    update?: Expression | null | undefined;
+    body: Statement;
+}
+
+/** Node having nearly the same structure as `estree.ForInStatement`. */
+export interface ForInStatement extends BaseStatement {
+    type: 'ForInStatement';
+    left: Identifier | IndirectPattern; // Unlike JavaScript, VariableDeclaration is unavailable here.
+    right: Expression;
+    body: Statement;
+}
+
+/** Node similar to `estree.BreakStatement`, just lacking "label" property. */
+export interface BreakStatement extends BaseStatement {
+    type: 'BreakStatement';
+}
+
+/** Node similar to `estree.ContinueStatement`, just lacking "label" property. */
+export interface ContinueStatement extends BaseStatement {
+    type: 'ContinueStatement';
+}
+
+/** Node having the same structure as `estree.ReturnStatement`. */
+export interface ReturnStatement extends BaseStatement {
+    type: 'ReturnStatement';
+    argument?: Expression | null | undefined;
+}
+
+/** Node specific to __spec__, no counterpart in ESTree. */
+export interface ExitStatement extends BaseStatement {
+    type: 'ExitStatement';
+}
+
+/** Node specific to __spec__, no counterpart in ESTree. */
+export interface QuitStatement extends BaseStatement {
+    type: 'QuitStatement';
+}
+
+// export type Declaration = FunctionDeclaration | VariableDeclaration | ClassDeclaration;
+
+export interface BaseDeclaration extends BaseStatement {}
+
+/**
+ * Node similar to `estree.FunctionDeclaration`.
+ *
+ * This also covers a traditional macro, in that case `params === null`
+ * (and in case of a macro function without parameters, `params === []`).
+ * The structure is simpler than it since __spec__ does not support
+ * anonymous functions or arrow functions.
+*/
+export interface FunctionDeclaration extends BaseStatement, BaseDeclaration {
+    type: 'FunctionDeclaration';
+    id: Identifier;
+    params: Identifier[] | null; // Pattern[];
+    body: BlockStatement;
+    rdef: boolean;
+}
+
+/**
+ * Node similar to `estree.VariableDeclaration`.
+ *
+ * This covers declarations of both variables (scalar and associative array)
+ * and data arrays.
+*/
+export interface BaseVariableDeclaration extends BaseStatement, BaseDeclaration {
+    type: 'VariableDeclaration';
+    dataarray: boolean;
+    declarations: BaseVariableDeclarator[];
+    kind?: 'global' | 'local' | 'const' | 'shared' | 'extern' | undefined;
+    datatype?: DataArrayUnit | null | undefined;
+}
+
+/** Node for variable declaration. */
+export interface VariableDeclaration extends BaseVariableDeclaration {
+    dataarray: false;
+    kind: 'global' | 'local' | 'const';
+    declarations: VariableDeclarator[];
+    datatype: never;
+}
+
+/** Node for data array declaration. */
+export interface DataArrayDeclaration extends BaseVariableDeclaration {
+    dataarray: true;
+    kind: 'global' | 'local' | 'shared' | 'extern' | undefined;
+    declarations: (InternalDataArrayDeclarator | ExternalDataArrayDeclarator)[];
+    datatype: DataArrayUnit;
+}
+
+/** Node similar to `estree.VariableDeclarator`.
+ *
+ * This covers declarators of variables (scalar and associative array),
+ * internal data arrays, and external data arrays.
+*/
+export interface BaseVariableDeclarator extends BaseNode {
+    type: 'VariableDeclarator';
+    id: Identifier | IndirectPattern;
+    assocarray?: boolean;
+    init?: Expression | null | undefined;
+    extern?: { spec?: string | undefined, pid?: number | undefined, raw: string, } | undefined;  // for external data array declaration.
+    sizes? : Expression[] | undefined; // for internal data array declaration.
+}
+
+/** Node for a variable declarator. */
+export interface VariableDeclarator extends BaseVariableDeclarator {
+    assocarray: boolean;
+    extern: never;
+    sizes : never;
+}
+
+/** Node for internal data array declarator. */
+export interface InternalDataArrayDeclarator extends BaseVariableDeclarator {
+    assocarray: never;
+    init: never;
+    extern: never;
+    sizes : Expression[];
+}
+
+/** Node for external data array declarator. */
+export interface ExternalDataArrayDeclarator extends BaseVariableDeclarator {
+    assocarray: never;
+    init: never;
+    extern: { spec?: string | undefined, pid?: number | undefined, raw: string, };
+    size: never;
+}
+
+
+type DataArrayUnit =
+    | 'string' | 'float' | 'double'
+    | 'byte' | 'short' | 'long' | 'long64'
+    | 'ubyte' | 'ushort' | 'ulong' | 'ulong64';
+
+/** Node specific to __spec__, no counterpart in ESTree. */
+export interface MacroStatement extends BaseStatement, BaseDeclaration {
+    type: 'MacroStatement';
+    callee: Identifier;
+    arguments: Expression[];
+    builtin?: boolean | undefined;
+}
+
+/** Node having the same structure as `estree.ExpressionStatement`. */
+export interface ExpressionStatement extends BaseStatement {
+    type: 'ExpressionStatement';
+    expression: Expression;
+}
+
+// expression
+
+export interface BaseExpression extends BaseNode { }
+
+export interface ExpressionMap {
+    SequenceExpression: SequenceExpression;
+    UnaryExpression: UnaryExpression;
+    BinaryExpression: BinaryExpression;
+    AssignmentExpression: AssignmentExpression;
+    UpdateExpression: UpdateExpression;
+    LogicalExpression: LogicalExpression;
+    ConditionalExpression: ConditionalExpression;
+    CallExpression: CallExpression;
+    MemberExpression: MemberExpression;
+    Identifier: Identifier;
+    Literal: Literal;
+    ArrayPattern: ArrayPattern;
+    IndirectPattern: IndirectPattern;
+    // ArrayExpression: ArrayExpression;
+    ObjectExpression: ObjectExpression;
+    UnclassifiedExpression: UnclassifiedExpression;    
+}
+
+export type Expression = ExpressionMap[keyof ExpressionMap];
+
+
+// export interface EmptyExpression extends BaseExpression {
+//     type: 'EmptyExpression';
+// }
+
+// type LValue = BaseExpression; // TODO: limit to more specific types.
+
+/**
+ * Node having the same structure as `estree.SequenceExpression`.
+ *
+ * This can be used only at `init` and `update` of `ForStatement` and `ExpressionStatement`.
+ * In this sense, it is not a strict member of `Expression`.
+ */
+export interface SequenceExpression extends BaseExpression {
+    type: 'SequenceExpression';
+    expressions: Expression[];
+}
+
+export interface UnaryExpression extends BaseExpression {
+    type: 'UnaryExpression';
+    operator: UnaryOperator;
+    prefix: true;
+    argument: Expression;
+}
+
+export interface BinaryExpression extends BaseExpression {
+    type: 'BinaryExpression';
+    operator: BinaryOperator;
+    left: Expression;
+    right: Expression;
+}
+
+// TODO: more precise type for `left`
+export interface AssignmentExpression extends BaseExpression {
+    type: 'AssignmentExpression';
+    operator: AssignmentOperator;
+    left: Identifier | IndirectPattern | MemberExpression;
+    right: Expression;
+}
+
+/** Node close to `estree.UpdateExpression`. */
+export interface UpdateExpression extends BaseExpression {
+    type: 'UpdateExpression';
+    operator: UpdateOperator;
+    argument: Pattern; // Expression;
+    prefix: boolean;
+}
+
+/** Node the same as `estree.LogicalExpression`. */
+export interface LogicalExpression extends BaseExpression {
+    type: 'LogicalExpression';
+    operator: LogicalOperator;
+    left: Expression;
+    right: Expression;
+}
+
+/** Node the same as `estree.ConditionalExpression`. */
+export interface ConditionalExpression extends BaseExpression {
+    type: 'ConditionalExpression';
+    test: Expression;
+    alternate: Expression;
+    consequent: Expression;
+}
+
+/** 
+ * Node having a similar structure as `estree.BaseCallExpression`.
+ * 
+ * The type of a callee in __spec__ is much more limited than JavaScript.
+ */
+export interface CallExpression extends BaseExpression {
+    type: 'CallExpression';
+    callee: Pattern; // Expression | Super;
+    arguments: Expression[];
+}
+
+export type UnaryOperator = '+' | '-' | '!' | '~';
+
+export type BinaryOperator =
+    | '+'
+    | '-'
+    | '*'
+    | '/'
+    | '%'
+    | '<<'
+    | '>>'
+    | '<'
+    | '<='
+    | '>'
+    | '>='
+    | '=='
+    | '!='
+    | '&'
+    | '^'
+    | '|'
+    | ':'
+    | ' '; // used for string concatenation.
+
+export type LogicalOperator = '||' | '&&';
+
+export type AssignmentOperator =
+    | '='
+    | '+='
+    | '-='
+    | '*='
+    | '/='
+    | '%='
+    | '<<='
+    | '>>='
+    | '&='
+    | '^='
+    | '|=';
+
+export type UpdateOperator = '++' | '--';
+
+
+export type Pattern = Identifier | IndirectPattern | MemberExpression;
+
+/** Identifier, similar to `estree.Identifier` .*/
+interface Identifier extends BaseExpression, BasePattern {
+    type: 'Identifier';
+    name: string;
+    params: MacroParameter[] | undefined;
+}
+
+/** Node specific to __spec__, no counterpart in ESTree. */
+export interface MacroParameter extends BaseNode {
+    type: 'MacroParameter';
+    name: string;
+}
+
+/** 
+ * Literal value, either string or number.
+ * This is similar to `estree.SimpleLiteral` but does not
+ * contain `boolean` in `value` property.
+ */
+export interface Literal extends BaseExpression {
+    type: 'Literal';
+    value: string | number | null;
+    raw?: string | undefined;
+}
+
+export interface BasePattern extends BaseNode {}
+
+// export interface AssignmentPattern extends BasePattern {
+//     type: 'AssignmentPattern';
+//     left: Identifier;
+//     right: Expression;
+// }
+
+/** Node similar to `estree.ArrayPattern`. */
+export interface ArrayPattern extends BaseExpression, BasePattern {
+    type: 'ArrayPattern';
+    elements: (Expression | null)[] // Array<Pattern | null>;
+}
+
+/**
+ * Node specific to __spec__, no counterpart in ESTree.
+ * 
+ * Reference to a variable using indirect operator "@" and
+ * a following expression.
+ */
+interface IndirectPattern extends BaseExpression, BasePattern {
+    type: 'IndirectPattern';
+    expression: Expression;
+}
+
+/**
+ * Node similar to `estree.MemberExpression` but having "properties" 
+ * instead of "property".
+ * e.g., `assoc_array[]`, `data_array[1, 3:5][4]`
+ */
+export interface MemberExpression extends BaseExpression, BasePattern {
+    type: 'MemberExpression';
+    object: Identifier | IndirectPattern; // Expression;
+    properties: MemberAccessProperty[]; // property: Expression;
+}
+
+/**  Node specific to __spec__, no counterpart in ESTree. */
+export interface MemberAccessProperty extends BaseNode {
+    type: 'MemberAccessProperty';
+    values: (Expression | SliceElement)[];
+}
+
+/**  Node specific to __spec__, no counterpart in ESTree. */
+export interface SliceElement extends BaseNode {
+    type: 'SliceElement';
+    start: Expression;
+    end: Expression;
+}
+
+// export interface ArrayExpression extends BaseExpression {
+//     type: 'ArrayExpression';
+//     elements: Expression[];
+//     kind: 'brace' | 'bracket' | 'parenthesis'; // `{}` | `[]` | `()`
+// }
+
+/** Node similar to `estree.ObjectExpression`. */
+export interface ObjectExpression extends BaseExpression {
+    type: 'ObjectExpression';
+    properties: Expression[]; // Array<Property | SpreadElement>;
+}
+
+/** Node similar to `estree.Property`. */
+export interface Property extends BaseNode {
+    type: 'Property';
+    key: Expression;
+    value: Expression | Pattern;
+    kind: 'init';
+}
+
+export interface UnclassifiedExpression extends BaseExpression {
+    type: 'UnclassifiedExpression';
+    raw?: string | undefined;
+}

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -40,7 +40,7 @@ The license of the referred file is as follows:
  */
 
 import type { DiagnosticSeverity } from 'vscode';
-import type { LocationRange } from './grammar';
+import type { LocationRange } from './parser';
 
 /**
  * Node having a similar structure as `estree.BaseNodeWithoutComments`.

--- a/src/userProvider.ts
+++ b/src/userProvider.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import * as lang from './specCommand';
 import { Provider } from './provider';
 import { traversePartially, traverseWholly } from './traverser';
-import { SyntaxError, parse } from './grammar';
+import { SyntaxError, parse } from './parser';
 import type * as tree from './tree';
 
 


### PR DESCRIPTION
Restructure of code for further enhancement.

- AST now has own types, not ones borrowed from ESTree.
- Fix some other parser rules.
- Use an object instead of Map for per-file storage of symbols.
- Separate traverser code in `userProvider.ts` into `traverser.ts`.
- Rename several file names and symbol names.