### PR TITLE
feat: make parser cancellation-aware

### DIFF
--- a/src/traverser.ts
+++ b/src/traverser.ts
@@ -286,7 +286,7 @@ export function traversePartially(program: tree.Program, position: vscode.Positi
     return refBook;
 }
 
-export function traverseForFurtherDiagnostics(program: tree.Program, referenceCollection: Map<string, lang.ReferenceBook>): vscode.Diagnostic[] {
+export function traverseForFurtherDiagnostics(program: tree.Program, referenceBooks: Iterable<lang.ReferenceBook>) {
     const diagnostics: vscode.Diagnostic[] = [];
     const blockStack: tree.BlockStatement[] = [];
     // type RefBookKey = 'variable' | 'array' | 'constant';
@@ -340,7 +340,7 @@ export function traverseForFurtherDiagnostics(program: tree.Program, referenceCo
                     return;
                 }
                 let flag = false;
-                for (const refBook2 of refBookStack.concat([...referenceCollection.values()])) {
+                for (const refBook2 of refBookStack.concat(...referenceBooks)) {
                     if (refBook2.has(node.name)) {
                         flag = true;
                         break;


### PR DESCRIPTION
Fixes #37

Made most parser action and provider's callback functions asyncronous and then make user of cancellation token during document symbol update.

Still there's room to add check of cancellation token but I'll close the PR and related issue, as this already contains big progress.